### PR TITLE
fix: ensure that the correct license identifier is reported in SBOM

### DIFF
--- a/lib/action/index.js
+++ b/lib/action/index.js
@@ -8686,18 +8686,20 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.licenseMap = exports.load = void 0;
 const spdx = __importStar(__nccwpck_require__(5967));
+const utils_1 = __nccwpck_require__(1314);
 // Regex which matches "key: value" with multiline support
 const DEBIAN_PACKAGE_REGEX = /(?<key>[^:]+):\s*(?<value>[^[\r\n]+]*([\r\n]+\s+[^[\r\n]+]*)*)/g;
-/**
- * Converts a kebab-case string to camelCase
- * @param str String to convert to camelCase
- * @returns camelCase string
- */
-function kebabToCamel(str) {
-    return str
-        .split("-")
-        .map((word, index) => (index === 0 ? word.toLowerCase() : word[0].toUpperCase() + word.slice(1).toLowerCase()))
-        .join("");
+function getDebianKeyValuePairs(stanza) {
+    const result = {};
+    const matches = stanza.matchAll(DEBIAN_PACKAGE_REGEX);
+    for (const match of matches) {
+        // Skip invalid matches
+        if ((match === null || match === void 0 ? void 0 : match.groups) === undefined)
+            continue;
+        // Retrieve key/value pairs
+        result[(0, utils_1.kebabToCamel)(match.groups.key.trim())] = match.groups.value.trim();
+    }
+    return result;
 }
 /**
  * Parses the provided header string into a DebianHeader object
@@ -8708,42 +8710,13 @@ function parseHeader(header) {
     const headerData = {
         format: "1.0",
     };
-    const matches = header.matchAll(DEBIAN_PACKAGE_REGEX);
-    for (const match of matches) {
-        // Skip invalid matches
-        if ((match === null || match === void 0 ? void 0 : match.groups) === undefined)
-            continue;
-        // Retrieve key/value pairs
-        const key = kebabToCamel(match.groups.key.trim());
-        const value = match.groups.value.trim();
-        // TODO: Remove the need for this switch statement
-        switch (key) {
-            case "format":
-                headerData.format = value;
-                break;
-            case "upstreamName":
-                headerData.upstreamName = value;
-                break;
-            case "upstreamContact":
-                headerData.upstreamContact = value;
-                break;
-            case "source":
-                headerData.source = value;
-                break;
-            case "disclaimer":
-                headerData.disclaimer = value;
-                break;
-            case "comment":
-                headerData.comment = value;
-                break;
-            case "license":
-                headerData.license = value;
-                break;
-            case "copyright":
-                headerData.copyright = value.split(/[\r\n]+/).map(line => line.trim());
-                break;
-        }
-    }
+    Object.entries(getDebianKeyValuePairs(header)).forEach(([key, value]) => {
+        const headerKey = key;
+        if (headerKey === "copyright")
+            headerData[headerKey] = value.split(/[\r\n]+/).map(line => line.trim());
+        else
+            headerData[headerKey] = value;
+    });
     return headerData;
 }
 /**
@@ -8757,15 +8730,7 @@ function parseFileStanza(stanza) {
         license: "",
         copyright: [],
     };
-    const matches = stanza.matchAll(DEBIAN_PACKAGE_REGEX);
-    for (const match of matches) {
-        // Skip invalid matches
-        if ((match === null || match === void 0 ? void 0 : match.groups) === undefined)
-            continue;
-        // Retrieve key/value pairs
-        const key = kebabToCamel(match.groups.key.trim());
-        const value = match.groups.value.trim();
-        // TODO: Remove the need for this switch statement
+    Object.entries(getDebianKeyValuePairs(stanza)).forEach(([key, value]) => {
         switch (key) {
             case "files":
                 filesStanza.files = value
@@ -8783,7 +8748,7 @@ function parseFileStanza(stanza) {
                 filesStanza.comment = value;
                 break;
         }
-    }
+    });
     return filesStanza;
 }
 /**
@@ -8792,9 +8757,8 @@ function parseFileStanza(stanza) {
  */
 function load(config) {
     const stanzas = config.split(/[\r\n]+\s*[\r\n]+/);
-    if (stanzas.length === 0) {
+    if (stanzas.length === 0)
         throw new Error("No stanzas found");
-    }
     return {
         header: parseHeader(stanzas[0]),
         files: stanzas.slice(1).map(stanza => parseFileStanza(stanza)),
@@ -8819,11 +8783,10 @@ exports.load = load;
 function wildcardMatch(fileName, pattern) {
     if (pattern === "*")
         return true;
-    const regexp = new RegExp(`^${pattern
+    return new RegExp(`^${pattern
         .split("*")
         .map(s => s.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&"))
-        .join(".*")}$`);
-    return regexp.test(fileName);
+        .join(".*")}$`).test(fileName);
 }
 /**
  * Creates a mapping between files specified in the Debian Package and their respective SPDX headers
@@ -8835,17 +8798,14 @@ function licenseMap(debianPackage, files) {
     const fileMap = new Map();
     for (const packageFiles of debianPackage.files) {
         for (const patternFile of packageFiles.files) {
-            for (const file of files) {
-                const filePath = file.source === "original" ? file.filePath : file.licensePath;
-                if (wildcardMatch(filePath, patternFile)) {
-                    // REUSE-IgnoreStart
-                    const spdxFile = spdx.parseFile(filePath, `${packageFiles.copyright
-                        .map(copyright => `SPDX-FileCopyrightText: ${copyright}`)
-                        .join("\n")}\nSPDX-License-Identifier: ${packageFiles.license}`);
-                    // REUSE-IgnoreEnd
-                    fileMap.set(filePath, spdxFile);
-                }
-            }
+            files
+                .filter(file => wildcardMatch((0, utils_1.getSourceFile)(file), patternFile))
+                .forEach(file => fileMap.set((0, utils_1.getSourceFile)(file), spdx.parseFile((0, utils_1.getSourceFile)(file), `${packageFiles.copyright
+                // REUSE-IgnoreStart
+                .map(copyright => `SPDX-FileCopyrightText: ${copyright}`)
+                .join("\n")}\nSPDX-License-Identifier: ${packageFiles.license}`
+            // REUSE-IgnoreEnd
+            )));
         }
     }
     return fileMap;
@@ -8990,6 +8950,7 @@ exports.projectRequirements = exports.fileRequirements = exports.RequirementErro
 const diagnose_it_1 = __nccwpck_require__(4657);
 const spdx = __importStar(__nccwpck_require__(5967));
 const fs = __importStar(__nccwpck_require__(7147));
+const spdx_1 = __nccwpck_require__(5967);
 /**
  * Error thrown when a commit message does not meet the Conventional Commit specification.
  */
@@ -9073,20 +9034,11 @@ class PR01 {
     }
     validate(sbom) {
         const error = new RequirementError(this, sbom.name);
-        const allLicenses = [];
-        const missingLicenses = [];
-        sbom.files.forEach(file => {
-            file.licenseInfoInFiles
-                .filter(license => license !== "NOASSERTION")
-                .forEach(license => {
-                if (allLicenses.includes(license) === false)
-                    allLicenses.push(license);
-                if (fs.existsSync(`./LICENSES/${license}.txt`) === false) {
-                    if (missingLicenses.includes(license) === false)
-                        missingLicenses.push(license);
-                }
-            });
-        });
+        const allLicenses = sbom.files
+            .map(file => (0, spdx_1.getIndividualLicences)(file))
+            .flat()
+            .filter((value, index, array) => array.indexOf(value) === index);
+        const missingLicenses = allLicenses.filter(license => fs.existsSync(`./LICENSES/${license}.txt`) === false);
         missingLicenses.forEach(license => {
             error.addError(["Project MUST include a License File for", license], `The Project MUST include a License File for every license, but is missing ${license}`);
         });
@@ -9103,9 +9055,7 @@ class PR02 {
         const error = new RequirementError(this, sbom.name);
         const localLicenses = [...licenses];
         sbom.files.forEach(file => {
-            file.licenseInfoInFiles
-                .filter(license => license !== "NOASSERTION")
-                .forEach(license => {
+            (0, spdx_1.getIndividualLicences)(file).forEach(license => {
                 if (localLicenses.includes(`LICENSES/${license}.txt`) === true)
                     localLicenses.splice(localLicenses.indexOf(`LICENSES/${license}.txt`), 1);
                 if (localLicenses.length === 0)
@@ -9169,9 +9119,16 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.parseFile = exports.isReuseCompliant = exports.hasValidLicense = exports.hasValidCopyrightText = exports.SoftwareBillOfMaterials = void 0;
+exports.getIndividualLicences = exports.isReuseCompliant = exports.hasValidCopyrightText = exports.hasValidLicense = exports.parseFile = exports.SoftwareBillOfMaterials = void 0;
 const debian = __importStar(__nccwpck_require__(8974));
 const crypto = __importStar(__nccwpck_require__(6113));
+const utils_1 = __nccwpck_require__(1314);
+/**
+ * SPDX Document
+ * @class SoftwareBillOfMaterials
+ * @implements ISoftwareBillOfMaterials
+ * @see https://spdx.github.io/spdx-spec/2-document-creation-information/
+ */
 class SoftwareBillOfMaterials {
     constructor(name, datasource) {
         this.SPDXID = "SPDXRef-DOCUMENT";
@@ -9197,24 +9154,18 @@ class SoftwareBillOfMaterials {
      */
     createFile(file, debianLicenseMap) {
         return __awaiter(this, void 0, void 0, function* () {
-            const fileName = file.source === "original" ? file.filePath : file.licensePath;
-            // Determine the SPDX header of the file
-            let spdxFile;
+            const fileName = (0, utils_1.getSourceFile)(file);
             // First we check whether the file is matched in the Debian package configuration
             const debianFileLicense = debianLicenseMap.get(file.filePath);
-            if (debianFileLicense !== undefined) {
-                spdxFile = debianFileLicense;
-            }
+            if (debianFileLicense !== undefined && isReuseCompliant(debianFileLicense))
+                return debianFileLicense;
             // Next we check for an available .license file, as part of optimization for large
             // binary files.
-            if (spdxFile === undefined || isReuseCompliant(spdxFile) === false) {
-                spdxFile = parseFile(fileName, yield this.datasource.getFileContents(file.licensePath));
-            }
+            const licenseFileLicense = parseFile(fileName, yield this.datasource.getFileContents(file.licensePath));
+            if (isReuseCompliant(licenseFileLicense))
+                return licenseFileLicense;
             // Otherwise, we check the original file.
-            if (isReuseCompliant(spdxFile) === false) {
-                spdxFile = parseFile(fileName, yield this.datasource.getFileContents(file.filePath));
-            }
-            return spdxFile;
+            return parseFile(fileName, yield this.datasource.getFileContents(file.filePath));
         });
     }
     /**
@@ -9227,25 +9178,22 @@ class SoftwareBillOfMaterials {
             const debianConfig = debian.load(yield this.datasource.getFileContents(".reuse/dep5", false));
             const debianLicenseMap = debianConfig ? debian.licenseMap(debianConfig, changedFiles) : new Map();
             // Validate each file asynchronously
-            const promises = [];
-            for (const file of changedFiles) {
-                // Skip files in the LICENSES/ directory
-                if (file.filePath.startsWith("LICENSES/") || file.filePath === ".reuse/dep5" || file.filePath === "LICENSE.txt")
-                    continue;
-                promises.push(this.createFile(file, debianLicenseMap));
-            }
-            return yield Promise.all(promises);
+            return yield Promise.all(changedFiles
+                .filter(file => !(file.filePath.startsWith("LICENSES/") ||
+                file.filePath === ".reuse/dep5" ||
+                file.filePath === "LICENSE.txt"))
+                .map(file => this.createFile(file, debianLicenseMap)));
         });
     }
     generate() {
         return __awaiter(this, void 0, void 0, function* () {
             this.files = yield this.gatherFiles();
-            this.files.forEach(file => {
-                this.relationships.push({
+            this.relationships = this.files.map(file => {
+                return {
                     spdxElementId: "SPDXRef-DOCUMENT",
                     relationshipType: "DESCRIBES",
                     relatedSpdxElement: file.SPDXID,
-                });
+                };
             });
         });
     }
@@ -9273,16 +9221,11 @@ exports.SoftwareBillOfMaterials = SoftwareBillOfMaterials;
  * @param contents Contents of the file
  * @returns SPDX File entry
  */
-const parseFile = (fileName, contents) => {
+function parseFile(fileName, contents) {
     var _a;
     const file = {
         SPDXID: `SPDXRef-${crypto.createHash("SHA1").update(fileName).digest("hex")}`,
-        checksums: [
-            {
-                algorithm: "SHA1",
-                checksumValue: crypto.createHash("SHA1").update(contents).digest("hex"),
-            },
-        ],
+        checksums: [{ algorithm: "SHA1", checksumValue: crypto.createHash("SHA1").update(contents).digest("hex") }],
         fileContributors: [],
         fileName: fileName.startsWith("./") ? fileName : `./${fileName}`,
         fileTypes: [],
@@ -9294,8 +9237,6 @@ const parseFile = (fileName, contents) => {
     const SPDXLicenseHeaderRegex = /SPDX-License-Identifier:\s*(?<identifier>(.*)+)/g;
     const SPDXCopyrightRegex = /^[\W]*(©|[Cc]opyright|\([Cc]\)|SPDX-FileCopyrightText:)\s+(?<identifier>(.*)+)/gm;
     const SPDXCopyrightIdentifierRegex = /(?<year>[\d,-\s]*)\s*(?<copyrightHolder>[^<\n\r]*)\s(<(?<contactAddress>.*)>)?/;
-    // const SPDXCopyrightRegex =
-    //  /(©|[Cc]opyright|\([Cc]\))*\s*(?<year>[\d,-\s]*)\s*(?<copyrightHolder>[^<\n\r]*)\s(<(?<contactAddress>.*)>)?/;
     const SPDXFileTagRegex = /SPDX-File(?<key>[A-Za-z]*):\s*(?<value>.*)/g;
     const ReuseIgnoreRegex = /REUSE-IgnoreStart[\s\S]*REUSE-IgnoreEnd/g;
     // REUSE-IgnoreEnd
@@ -9306,11 +9247,9 @@ const parseFile = (fileName, contents) => {
     for (const match of licenseMatches) {
         if ((match === null || match === void 0 ? void 0 : match.groups) === undefined)
             continue;
-        const licenses = (_a = match.groups) === null || _a === void 0 ? void 0 : _a.identifier.split(/( AND | OR )/).filter(license => license !== " AND " && license !== " OR ");
-        licenses.forEach(license => {
-            if (file.licenseInfoInFiles.includes(license.trim()) === false)
-                file.licenseInfoInFiles.push(license.trim());
-        });
+        const license = (_a = match.groups) === null || _a === void 0 ? void 0 : _a.identifier.trim();
+        if (!file.licenseInfoInFiles.includes(license))
+            file.licenseInfoInFiles.push(license);
     }
     const copyrightMatches = strippedContents.matchAll(SPDXCopyrightRegex);
     for (const match of copyrightMatches) {
@@ -9361,26 +9300,76 @@ const parseFile = (fileName, contents) => {
         file.licenseInfoInFiles = file.licenseInfoInFiles.filter(license => license !== "NOASSERTION");
     }
     return file;
-};
+}
 exports.parseFile = parseFile;
-const hasValidLicense = (file) => {
+function hasValidLicense(file) {
     return (file.licenseInfoInFiles.length > 0 &&
         !(file.licenseInfoInFiles.length === 1 && file.licenseInfoInFiles[0] === "NOASSERTION"));
-};
+}
 exports.hasValidLicense = hasValidLicense;
-const hasValidCopyrightText = (file) => {
+function hasValidCopyrightText(file) {
     return file.copyrightText !== undefined && file.copyrightText !== "";
-};
+}
 exports.hasValidCopyrightText = hasValidCopyrightText;
 /**
  * Validates whether the provided header is a valid SPDX header.
  * @param header SPDX header to validate
  * @returns True if the header is valid, false otherwise
  */
-const isReuseCompliant = (file) => {
+function isReuseCompliant(file) {
     return hasValidLicense(file) && hasValidCopyrightText(file);
-};
+}
 exports.isReuseCompliant = isReuseCompliant;
+/**
+ * Extracts all individual license names from the license information in file.
+ * @param file SPDX file to extract the licenses from
+ * @returns List of individual licenses
+ */
+function getIndividualLicences(file) {
+    return file.licenseInfoInFiles
+        .filter(license => license !== "NOASSERTION")
+        .map(license => license.split(/( AND | OR )/))
+        .flat()
+        .filter(license => license !== " AND " && license !== " OR ");
+}
+exports.getIndividualLicences = getIndividualLicences;
+
+
+/***/ }),
+
+/***/ 1314:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+/*
+SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+*/
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.getSourceFile = exports.kebabToCamel = void 0;
+/**
+ * Converts a kebab-case string to camelCase
+ * @param str String to convert to camelCase
+ * @returns camelCase string
+ */
+function kebabToCamel(str) {
+    return str
+        .split("-")
+        .map((word, index) => (index === 0 ? word.toLowerCase() : word[0].toUpperCase() + word.slice(1).toLowerCase()))
+        .join("");
+}
+exports.kebabToCamel = kebabToCamel;
+/**
+ * Determines the source of the file
+ * @param file The file to determine the source of
+ * @returns The source of the file
+ */
+function getSourceFile(file) {
+    return file.source === "original" ? file.filePath : file.licensePath;
+}
+exports.getSourceFile = getSourceFile;
 
 
 /***/ }),
@@ -9404,23 +9393,15 @@ const requirements_1 = __nccwpck_require__(767);
  * @returns List of validation results
  */
 function validateFiles(sbom) {
-    const results = [];
-    for (const file of sbom.files) {
-        const result = {
-            file: file,
-            compliant: true,
-            errors: [],
-        };
-        for (const req of requirements_1.fileRequirements) {
-            const errors = req.validate(file);
-            if (errors === undefined)
-                continue;
-            result.compliant = false;
-            result.errors.push(...errors.errors.map(e => e.toString()));
-        }
-        results.push(result);
-    }
-    return results;
+    return sbom.files.map(file => {
+        const errors = requirements_1.fileRequirements
+            .map(req => req.validate(file))
+            .filter(errors => errors !== undefined)
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            .map(errors => errors.errors.map(e => e.toString()))
+            .flat();
+        return { file: file, compliant: errors.length === 0, errors: errors };
+    });
 }
 exports.validateFiles = validateFiles;
 /**
@@ -9430,19 +9411,13 @@ exports.validateFiles = validateFiles;
  * @returns Validation result
  */
 function validateSBOM(sbom, licenses) {
-    const result = {
-        file: sbom.files[0],
-        compliant: true,
-        errors: [],
-    };
-    for (const req of requirements_1.projectRequirements) {
-        const errors = req.validate(sbom, licenses);
-        if (errors === undefined)
-            continue;
-        result.compliant = false;
-        result.errors.push(...errors.errors.map(e => e.toString()));
-    }
-    return result;
+    const errors = requirements_1.projectRequirements
+        .map(req => req.validate(sbom, licenses))
+        .filter(errors => errors !== undefined)
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        .map(errors => errors.errors.map(e => e.toString()))
+        .flat();
+    return { file: sbom.files[0], compliant: errors.length === 0, errors: errors };
 }
 exports.validateSBOM = validateSBOM;
 

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -5985,18 +5985,20 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.licenseMap = exports.load = void 0;
 const spdx = __importStar(__nccwpck_require__(967));
+const utils_1 = __nccwpck_require__(314);
 // Regex which matches "key: value" with multiline support
 const DEBIAN_PACKAGE_REGEX = /(?<key>[^:]+):\s*(?<value>[^[\r\n]+]*([\r\n]+\s+[^[\r\n]+]*)*)/g;
-/**
- * Converts a kebab-case string to camelCase
- * @param str String to convert to camelCase
- * @returns camelCase string
- */
-function kebabToCamel(str) {
-    return str
-        .split("-")
-        .map((word, index) => (index === 0 ? word.toLowerCase() : word[0].toUpperCase() + word.slice(1).toLowerCase()))
-        .join("");
+function getDebianKeyValuePairs(stanza) {
+    const result = {};
+    const matches = stanza.matchAll(DEBIAN_PACKAGE_REGEX);
+    for (const match of matches) {
+        // Skip invalid matches
+        if ((match === null || match === void 0 ? void 0 : match.groups) === undefined)
+            continue;
+        // Retrieve key/value pairs
+        result[(0, utils_1.kebabToCamel)(match.groups.key.trim())] = match.groups.value.trim();
+    }
+    return result;
 }
 /**
  * Parses the provided header string into a DebianHeader object
@@ -6007,42 +6009,13 @@ function parseHeader(header) {
     const headerData = {
         format: "1.0",
     };
-    const matches = header.matchAll(DEBIAN_PACKAGE_REGEX);
-    for (const match of matches) {
-        // Skip invalid matches
-        if ((match === null || match === void 0 ? void 0 : match.groups) === undefined)
-            continue;
-        // Retrieve key/value pairs
-        const key = kebabToCamel(match.groups.key.trim());
-        const value = match.groups.value.trim();
-        // TODO: Remove the need for this switch statement
-        switch (key) {
-            case "format":
-                headerData.format = value;
-                break;
-            case "upstreamName":
-                headerData.upstreamName = value;
-                break;
-            case "upstreamContact":
-                headerData.upstreamContact = value;
-                break;
-            case "source":
-                headerData.source = value;
-                break;
-            case "disclaimer":
-                headerData.disclaimer = value;
-                break;
-            case "comment":
-                headerData.comment = value;
-                break;
-            case "license":
-                headerData.license = value;
-                break;
-            case "copyright":
-                headerData.copyright = value.split(/[\r\n]+/).map(line => line.trim());
-                break;
-        }
-    }
+    Object.entries(getDebianKeyValuePairs(header)).forEach(([key, value]) => {
+        const headerKey = key;
+        if (headerKey === "copyright")
+            headerData[headerKey] = value.split(/[\r\n]+/).map(line => line.trim());
+        else
+            headerData[headerKey] = value;
+    });
     return headerData;
 }
 /**
@@ -6056,15 +6029,7 @@ function parseFileStanza(stanza) {
         license: "",
         copyright: [],
     };
-    const matches = stanza.matchAll(DEBIAN_PACKAGE_REGEX);
-    for (const match of matches) {
-        // Skip invalid matches
-        if ((match === null || match === void 0 ? void 0 : match.groups) === undefined)
-            continue;
-        // Retrieve key/value pairs
-        const key = kebabToCamel(match.groups.key.trim());
-        const value = match.groups.value.trim();
-        // TODO: Remove the need for this switch statement
+    Object.entries(getDebianKeyValuePairs(stanza)).forEach(([key, value]) => {
         switch (key) {
             case "files":
                 filesStanza.files = value
@@ -6082,7 +6047,7 @@ function parseFileStanza(stanza) {
                 filesStanza.comment = value;
                 break;
         }
-    }
+    });
     return filesStanza;
 }
 /**
@@ -6091,9 +6056,8 @@ function parseFileStanza(stanza) {
  */
 function load(config) {
     const stanzas = config.split(/[\r\n]+\s*[\r\n]+/);
-    if (stanzas.length === 0) {
+    if (stanzas.length === 0)
         throw new Error("No stanzas found");
-    }
     return {
         header: parseHeader(stanzas[0]),
         files: stanzas.slice(1).map(stanza => parseFileStanza(stanza)),
@@ -6118,11 +6082,10 @@ exports.load = load;
 function wildcardMatch(fileName, pattern) {
     if (pattern === "*")
         return true;
-    const regexp = new RegExp(`^${pattern
+    return new RegExp(`^${pattern
         .split("*")
         .map(s => s.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&"))
-        .join(".*")}$`);
-    return regexp.test(fileName);
+        .join(".*")}$`).test(fileName);
 }
 /**
  * Creates a mapping between files specified in the Debian Package and their respective SPDX headers
@@ -6134,17 +6097,14 @@ function licenseMap(debianPackage, files) {
     const fileMap = new Map();
     for (const packageFiles of debianPackage.files) {
         for (const patternFile of packageFiles.files) {
-            for (const file of files) {
-                const filePath = file.source === "original" ? file.filePath : file.licensePath;
-                if (wildcardMatch(filePath, patternFile)) {
-                    // REUSE-IgnoreStart
-                    const spdxFile = spdx.parseFile(filePath, `${packageFiles.copyright
-                        .map(copyright => `SPDX-FileCopyrightText: ${copyright}`)
-                        .join("\n")}\nSPDX-License-Identifier: ${packageFiles.license}`);
-                    // REUSE-IgnoreEnd
-                    fileMap.set(filePath, spdxFile);
-                }
-            }
+            files
+                .filter(file => wildcardMatch((0, utils_1.getSourceFile)(file), patternFile))
+                .forEach(file => fileMap.set((0, utils_1.getSourceFile)(file), spdx.parseFile((0, utils_1.getSourceFile)(file), `${packageFiles.copyright
+                // REUSE-IgnoreStart
+                .map(copyright => `SPDX-FileCopyrightText: ${copyright}`)
+                .join("\n")}\nSPDX-License-Identifier: ${packageFiles.license}`
+            // REUSE-IgnoreEnd
+            )));
         }
     }
     return fileMap;
@@ -6275,6 +6235,7 @@ exports.projectRequirements = exports.fileRequirements = exports.RequirementErro
 const diagnose_it_1 = __nccwpck_require__(657);
 const spdx = __importStar(__nccwpck_require__(967));
 const fs = __importStar(__nccwpck_require__(147));
+const spdx_1 = __nccwpck_require__(967);
 /**
  * Error thrown when a commit message does not meet the Conventional Commit specification.
  */
@@ -6358,20 +6319,11 @@ class PR01 {
     }
     validate(sbom) {
         const error = new RequirementError(this, sbom.name);
-        const allLicenses = [];
-        const missingLicenses = [];
-        sbom.files.forEach(file => {
-            file.licenseInfoInFiles
-                .filter(license => license !== "NOASSERTION")
-                .forEach(license => {
-                if (allLicenses.includes(license) === false)
-                    allLicenses.push(license);
-                if (fs.existsSync(`./LICENSES/${license}.txt`) === false) {
-                    if (missingLicenses.includes(license) === false)
-                        missingLicenses.push(license);
-                }
-            });
-        });
+        const allLicenses = sbom.files
+            .map(file => (0, spdx_1.getIndividualLicences)(file))
+            .flat()
+            .filter((value, index, array) => array.indexOf(value) === index);
+        const missingLicenses = allLicenses.filter(license => fs.existsSync(`./LICENSES/${license}.txt`) === false);
         missingLicenses.forEach(license => {
             error.addError(["Project MUST include a License File for", license], `The Project MUST include a License File for every license, but is missing ${license}`);
         });
@@ -6388,9 +6340,7 @@ class PR02 {
         const error = new RequirementError(this, sbom.name);
         const localLicenses = [...licenses];
         sbom.files.forEach(file => {
-            file.licenseInfoInFiles
-                .filter(license => license !== "NOASSERTION")
-                .forEach(license => {
+            (0, spdx_1.getIndividualLicences)(file).forEach(license => {
                 if (localLicenses.includes(`LICENSES/${license}.txt`) === true)
                     localLicenses.splice(localLicenses.indexOf(`LICENSES/${license}.txt`), 1);
                 if (localLicenses.length === 0)
@@ -6454,9 +6404,16 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.parseFile = exports.isReuseCompliant = exports.hasValidLicense = exports.hasValidCopyrightText = exports.SoftwareBillOfMaterials = void 0;
+exports.getIndividualLicences = exports.isReuseCompliant = exports.hasValidCopyrightText = exports.hasValidLicense = exports.parseFile = exports.SoftwareBillOfMaterials = void 0;
 const debian = __importStar(__nccwpck_require__(974));
 const crypto = __importStar(__nccwpck_require__(113));
+const utils_1 = __nccwpck_require__(314);
+/**
+ * SPDX Document
+ * @class SoftwareBillOfMaterials
+ * @implements ISoftwareBillOfMaterials
+ * @see https://spdx.github.io/spdx-spec/2-document-creation-information/
+ */
 class SoftwareBillOfMaterials {
     constructor(name, datasource) {
         this.SPDXID = "SPDXRef-DOCUMENT";
@@ -6482,24 +6439,18 @@ class SoftwareBillOfMaterials {
      */
     createFile(file, debianLicenseMap) {
         return __awaiter(this, void 0, void 0, function* () {
-            const fileName = file.source === "original" ? file.filePath : file.licensePath;
-            // Determine the SPDX header of the file
-            let spdxFile;
+            const fileName = (0, utils_1.getSourceFile)(file);
             // First we check whether the file is matched in the Debian package configuration
             const debianFileLicense = debianLicenseMap.get(file.filePath);
-            if (debianFileLicense !== undefined) {
-                spdxFile = debianFileLicense;
-            }
+            if (debianFileLicense !== undefined && isReuseCompliant(debianFileLicense))
+                return debianFileLicense;
             // Next we check for an available .license file, as part of optimization for large
             // binary files.
-            if (spdxFile === undefined || isReuseCompliant(spdxFile) === false) {
-                spdxFile = parseFile(fileName, yield this.datasource.getFileContents(file.licensePath));
-            }
+            const licenseFileLicense = parseFile(fileName, yield this.datasource.getFileContents(file.licensePath));
+            if (isReuseCompliant(licenseFileLicense))
+                return licenseFileLicense;
             // Otherwise, we check the original file.
-            if (isReuseCompliant(spdxFile) === false) {
-                spdxFile = parseFile(fileName, yield this.datasource.getFileContents(file.filePath));
-            }
-            return spdxFile;
+            return parseFile(fileName, yield this.datasource.getFileContents(file.filePath));
         });
     }
     /**
@@ -6512,25 +6463,22 @@ class SoftwareBillOfMaterials {
             const debianConfig = debian.load(yield this.datasource.getFileContents(".reuse/dep5", false));
             const debianLicenseMap = debianConfig ? debian.licenseMap(debianConfig, changedFiles) : new Map();
             // Validate each file asynchronously
-            const promises = [];
-            for (const file of changedFiles) {
-                // Skip files in the LICENSES/ directory
-                if (file.filePath.startsWith("LICENSES/") || file.filePath === ".reuse/dep5" || file.filePath === "LICENSE.txt")
-                    continue;
-                promises.push(this.createFile(file, debianLicenseMap));
-            }
-            return yield Promise.all(promises);
+            return yield Promise.all(changedFiles
+                .filter(file => !(file.filePath.startsWith("LICENSES/") ||
+                file.filePath === ".reuse/dep5" ||
+                file.filePath === "LICENSE.txt"))
+                .map(file => this.createFile(file, debianLicenseMap)));
         });
     }
     generate() {
         return __awaiter(this, void 0, void 0, function* () {
             this.files = yield this.gatherFiles();
-            this.files.forEach(file => {
-                this.relationships.push({
+            this.relationships = this.files.map(file => {
+                return {
                     spdxElementId: "SPDXRef-DOCUMENT",
                     relationshipType: "DESCRIBES",
                     relatedSpdxElement: file.SPDXID,
-                });
+                };
             });
         });
     }
@@ -6558,16 +6506,11 @@ exports.SoftwareBillOfMaterials = SoftwareBillOfMaterials;
  * @param contents Contents of the file
  * @returns SPDX File entry
  */
-const parseFile = (fileName, contents) => {
+function parseFile(fileName, contents) {
     var _a;
     const file = {
         SPDXID: `SPDXRef-${crypto.createHash("SHA1").update(fileName).digest("hex")}`,
-        checksums: [
-            {
-                algorithm: "SHA1",
-                checksumValue: crypto.createHash("SHA1").update(contents).digest("hex"),
-            },
-        ],
+        checksums: [{ algorithm: "SHA1", checksumValue: crypto.createHash("SHA1").update(contents).digest("hex") }],
         fileContributors: [],
         fileName: fileName.startsWith("./") ? fileName : `./${fileName}`,
         fileTypes: [],
@@ -6579,8 +6522,6 @@ const parseFile = (fileName, contents) => {
     const SPDXLicenseHeaderRegex = /SPDX-License-Identifier:\s*(?<identifier>(.*)+)/g;
     const SPDXCopyrightRegex = /^[\W]*(©|[Cc]opyright|\([Cc]\)|SPDX-FileCopyrightText:)\s+(?<identifier>(.*)+)/gm;
     const SPDXCopyrightIdentifierRegex = /(?<year>[\d,-\s]*)\s*(?<copyrightHolder>[^<\n\r]*)\s(<(?<contactAddress>.*)>)?/;
-    // const SPDXCopyrightRegex =
-    //  /(©|[Cc]opyright|\([Cc]\))*\s*(?<year>[\d,-\s]*)\s*(?<copyrightHolder>[^<\n\r]*)\s(<(?<contactAddress>.*)>)?/;
     const SPDXFileTagRegex = /SPDX-File(?<key>[A-Za-z]*):\s*(?<value>.*)/g;
     const ReuseIgnoreRegex = /REUSE-IgnoreStart[\s\S]*REUSE-IgnoreEnd/g;
     // REUSE-IgnoreEnd
@@ -6591,11 +6532,9 @@ const parseFile = (fileName, contents) => {
     for (const match of licenseMatches) {
         if ((match === null || match === void 0 ? void 0 : match.groups) === undefined)
             continue;
-        const licenses = (_a = match.groups) === null || _a === void 0 ? void 0 : _a.identifier.split(/( AND | OR )/).filter(license => license !== " AND " && license !== " OR ");
-        licenses.forEach(license => {
-            if (file.licenseInfoInFiles.includes(license.trim()) === false)
-                file.licenseInfoInFiles.push(license.trim());
-        });
+        const license = (_a = match.groups) === null || _a === void 0 ? void 0 : _a.identifier.trim();
+        if (!file.licenseInfoInFiles.includes(license))
+            file.licenseInfoInFiles.push(license);
     }
     const copyrightMatches = strippedContents.matchAll(SPDXCopyrightRegex);
     for (const match of copyrightMatches) {
@@ -6646,26 +6585,76 @@ const parseFile = (fileName, contents) => {
         file.licenseInfoInFiles = file.licenseInfoInFiles.filter(license => license !== "NOASSERTION");
     }
     return file;
-};
+}
 exports.parseFile = parseFile;
-const hasValidLicense = (file) => {
+function hasValidLicense(file) {
     return (file.licenseInfoInFiles.length > 0 &&
         !(file.licenseInfoInFiles.length === 1 && file.licenseInfoInFiles[0] === "NOASSERTION"));
-};
+}
 exports.hasValidLicense = hasValidLicense;
-const hasValidCopyrightText = (file) => {
+function hasValidCopyrightText(file) {
     return file.copyrightText !== undefined && file.copyrightText !== "";
-};
+}
 exports.hasValidCopyrightText = hasValidCopyrightText;
 /**
  * Validates whether the provided header is a valid SPDX header.
  * @param header SPDX header to validate
  * @returns True if the header is valid, false otherwise
  */
-const isReuseCompliant = (file) => {
+function isReuseCompliant(file) {
     return hasValidLicense(file) && hasValidCopyrightText(file);
-};
+}
 exports.isReuseCompliant = isReuseCompliant;
+/**
+ * Extracts all individual license names from the license information in file.
+ * @param file SPDX file to extract the licenses from
+ * @returns List of individual licenses
+ */
+function getIndividualLicences(file) {
+    return file.licenseInfoInFiles
+        .filter(license => license !== "NOASSERTION")
+        .map(license => license.split(/( AND | OR )/))
+        .flat()
+        .filter(license => license !== " AND " && license !== " OR ");
+}
+exports.getIndividualLicences = getIndividualLicences;
+
+
+/***/ }),
+
+/***/ 314:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+/*
+SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+*/
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.getSourceFile = exports.kebabToCamel = void 0;
+/**
+ * Converts a kebab-case string to camelCase
+ * @param str String to convert to camelCase
+ * @returns camelCase string
+ */
+function kebabToCamel(str) {
+    return str
+        .split("-")
+        .map((word, index) => (index === 0 ? word.toLowerCase() : word[0].toUpperCase() + word.slice(1).toLowerCase()))
+        .join("");
+}
+exports.kebabToCamel = kebabToCamel;
+/**
+ * Determines the source of the file
+ * @param file The file to determine the source of
+ * @returns The source of the file
+ */
+function getSourceFile(file) {
+    return file.source === "original" ? file.filePath : file.licensePath;
+}
+exports.getSourceFile = getSourceFile;
 
 
 /***/ }),
@@ -6689,23 +6678,15 @@ const requirements_1 = __nccwpck_require__(767);
  * @returns List of validation results
  */
 function validateFiles(sbom) {
-    const results = [];
-    for (const file of sbom.files) {
-        const result = {
-            file: file,
-            compliant: true,
-            errors: [],
-        };
-        for (const req of requirements_1.fileRequirements) {
-            const errors = req.validate(file);
-            if (errors === undefined)
-                continue;
-            result.compliant = false;
-            result.errors.push(...errors.errors.map(e => e.toString()));
-        }
-        results.push(result);
-    }
-    return results;
+    return sbom.files.map(file => {
+        const errors = requirements_1.fileRequirements
+            .map(req => req.validate(file))
+            .filter(errors => errors !== undefined)
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            .map(errors => errors.errors.map(e => e.toString()))
+            .flat();
+        return { file: file, compliant: errors.length === 0, errors: errors };
+    });
 }
 exports.validateFiles = validateFiles;
 /**
@@ -6715,19 +6696,13 @@ exports.validateFiles = validateFiles;
  * @returns Validation result
  */
 function validateSBOM(sbom, licenses) {
-    const result = {
-        file: sbom.files[0],
-        compliant: true,
-        errors: [],
-    };
-    for (const req of requirements_1.projectRequirements) {
-        const errors = req.validate(sbom, licenses);
-        if (errors === undefined)
-            continue;
-        result.compliant = false;
-        result.errors.push(...errors.errors.map(e => e.toString()));
-    }
-    return result;
+    const errors = requirements_1.projectRequirements
+        .map(req => req.validate(sbom, licenses))
+        .filter(errors => errors !== undefined)
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        .map(errors => errors.errors.map(e => e.toString()))
+        .flat();
+    return { file: sbom.files[0], compliant: errors.length === 0, errors: errors };
 }
 exports.validateSBOM = validateSBOM;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,28 @@
+/* 
+SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+import { ISourceFile } from "./interfaces";
+
+/**
+ * Converts a kebab-case string to camelCase
+ * @param str String to convert to camelCase
+ * @returns camelCase string
+ */
+export function kebabToCamel(str: string): string {
+  return str
+    .split("-")
+    .map((word, index) => (index === 0 ? word.toLowerCase() : word[0].toUpperCase() + word.slice(1).toLowerCase()))
+    .join("");
+}
+
+/**
+ * Determines the source of the file
+ * @param file The file to determine the source of
+ * @returns The source of the file
+ */
+export function getSourceFile(file: ISourceFile) {
+  return file.source === "original" ? file.filePath : file.licensePath;
+}


### PR DESCRIPTION
Previously, a license identifier `X OR Y` would be reported as
two seperate entries in the `licenseInfoInFiles` in the SBOM, whereas
this should have been kept in its original shape